### PR TITLE
Add tests for environment setup scripts

### DIFF
--- a/scripts/create_venv_env.sh
+++ b/scripts/create_venv_env.sh
@@ -13,6 +13,7 @@ ENV_DIR=".venv"
 INSTALL_DEV=0
 PYTHON_BIN=${PYTHON_BIN:-}
 EXPLICIT_PYTHON=0
+SKIP_PIP=${TEXT2UI_ENV_SETUP_SKIP_PIP:-0}
 [[ -n "$PYTHON_BIN" ]] && EXPLICIT_PYTHON=1
 
 while [[ $# -gt 0 ]]; do
@@ -151,19 +152,26 @@ if ! check_python_version "$VENV_PYTHON"; then
   exit 1
 fi
 
-echo "[INFO] Upgrading pip inside the virtual environment..."
-"$VENV_PYTHON" -m pip install --upgrade pip
+if (( SKIP_PIP )); then
+  echo "[INFO] Skipping pip-related installation steps due to TEXT2UI_ENV_SETUP_SKIP_PIP=${SKIP_PIP}."
+  if (( INSTALL_DEV )); then
+    echo "[WARN] Development extras requested but pip steps are skipped; dev dependencies were not installed."
+  fi
+else
+  echo "[INFO] Upgrading pip inside the virtual environment..."
+  "$VENV_PYTHON" -m pip install --upgrade pip
 
-# Ensure build tooling is present for packages that require modern CMake.
-echo "[INFO] Installing cmake>=3.25 inside the virtual environment..."
-"$VENV_PYTHON" -m pip install "cmake>=3.25"
+  # Ensure build tooling is present for packages that require modern CMake.
+  echo "[INFO] Installing cmake>=3.25 inside the virtual environment..."
+  "$VENV_PYTHON" -m pip install "cmake>=3.25"
 
-echo "[INFO] Installing Text2UI package in editable mode..."
-"$VENV_PYTHON" -m pip install -e .
+  echo "[INFO] Installing Text2UI package in editable mode..."
+  "$VENV_PYTHON" -m pip install -e .
 
-if (( INSTALL_DEV )); then
-  echo "[INFO] Installing development extras..."
-  "$VENV_PYTHON" -m pip install .[dev]
+  if (( INSTALL_DEV )); then
+    echo "[INFO] Installing development extras..."
+    "$VENV_PYTHON" -m pip install .[dev]
+  fi
 fi
 
 POSIX_ACTIVATE="source ${ENV_DIR}/bin/activate"

--- a/tests/test_env_scripts.py
+++ b/tests/test_env_scripts.py
@@ -1,0 +1,125 @@
+"""Tests for the environment setup helper scripts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+import textwrap
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = ROOT / "scripts"
+
+
+def _run_script(command: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    """Execute a shell script and capture its output."""
+    return subprocess.run(
+        command,
+        cwd=ROOT,
+        env=env,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_create_venv_env_skip_pip(tmp_path):
+    """The venv script should allow skipping pip-heavy operations for tests."""
+    env_dir = tmp_path / "test-venv"
+    script = SCRIPTS_DIR / "create_venv_env.sh"
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PYTHON_BIN": sys.executable,
+            "TEXT2UI_ENV_SETUP_SKIP_PIP": "1",
+        }
+    )
+
+    result = _run_script(["bash", str(script), str(env_dir)], env=env)
+
+    assert env_dir.exists(), "Virtual environment directory should be created."
+    assert "Skipping pip-related installation steps" in result.stdout
+    assert "[SETUP COMPLETE]" in result.stdout
+
+
+def _write_fake_solver(path: Path) -> None:
+    script_body = textwrap.dedent(
+        """\
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        LOG=${FAKE_SOLVER_LOG:?}
+        STATE=${FAKE_SOLVER_STATE:?}
+
+        printf "%s\n" "$*" >>"$LOG"
+
+        cmd=${1:-}
+        shift || true
+
+        case "$cmd" in
+          env)
+            if [[ ${1:-} == "list" ]]; then
+              if [[ -f "$STATE" ]]; then
+                cat "$STATE"
+              else
+                printf "#\n"
+              fi
+            fi
+            ;;
+          create)
+            env_name=""
+            while [[ $# -gt 0 ]]; do
+              case "$1" in
+                -n)
+                  env_name=$2
+                  shift 2
+                  ;;
+                *)
+                  shift
+                  ;;
+              esac
+            done
+            printf "%s\n" "$env_name" >"$STATE"
+            ;;
+          install|run)
+            :
+            ;;
+        esac
+        """
+    )
+    path.write_text(script_body)
+    path.chmod(0o755)
+
+
+def test_create_conda_env_with_fake_solver(tmp_path):
+    """The conda script can be exercised with a fake solver implementation."""
+    env_name = "text2ui-test"
+    script = SCRIPTS_DIR / "create_conda_env.sh"
+    fake_solver = tmp_path / "fake_solver.sh"
+    log_path = tmp_path / "solver.log"
+    state_path = tmp_path / "solver_state.txt"
+
+    log_path.write_text("")
+    _write_fake_solver(fake_solver)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "CONDA_SOLVER": str(fake_solver),
+            "FAKE_SOLVER_LOG": str(log_path),
+            "FAKE_SOLVER_STATE": str(state_path),
+            "TEXT2UI_ENV_SETUP_SKIP_DEPS": "1",
+            "PYTHON_VERSION": "3.10",
+        }
+    )
+
+    result = _run_script(["bash", str(script), env_name], env=env)
+
+    assert state_path.read_text().strip() == env_name
+    log_contents = log_path.read_text().splitlines()
+    assert any("env list" in entry for entry in log_contents)
+    assert any("create" in entry and env_name in entry for entry in log_contents)
+    assert "Skipping dependency installation" in result.stdout
+    assert "[SETUP COMPLETE]" in result.stdout


### PR DESCRIPTION
## Summary
- allow both environment setup scripts to skip dependency installation when TEXT2UI_* flags are set
- add pytest coverage that exercises the virtualenv script and the conda script using a fake solver

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb22508174832681d79ae7e00acefd