### PR TITLE
Use conda exclusively in environment setup script

### DIFF
--- a/scripts/create_conda_env.sh
+++ b/scripts/create_conda_env.sh
@@ -10,82 +10,36 @@ PYTHON_VERSION=${PYTHON_VERSION:-3.10}
 SKIP_DEPS=${TEXT2UI_ENV_SETUP_SKIP_DEPS:-0}
 
 UNAME=$(uname -s 2>/dev/null || echo "")
-SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-cleanup_paths=()
-cleanup() {
-  if ((${#cleanup_paths[@]})); then
-    rm -rf "${cleanup_paths[@]}"
+SOLVER_BIN="${CONDA_SOLVER:-}"
+if [[ -n "$SOLVER_BIN" ]]; then
+  if [[ ! -x "$SOLVER_BIN" ]]; then
+    if command -v "$SOLVER_BIN" >/dev/null 2>&1; then
+      SOLVER_BIN=$(command -v "$SOLVER_BIN")
+    else
+      echo "[ERROR] Unable to execute solver '$SOLVER_BIN'." >&2
+      exit 1
+    fi
   fi
-}
-trap cleanup EXIT
-
-bootstrap_micromamba() {
-  local tmp_dir archive url
-  tmp_dir=$(mktemp -d)
-  cleanup_paths+=("$tmp_dir")
-  archive="$tmp_dir/micromamba.tar.bz2"
-  url="https://micro.mamba.pm/api/micromamba/linux-64/latest"
-  echo "[INFO] Downloading a temporary micromamba binary for faster solves..."
-  if command -v curl >/dev/null 2>&1; then
-    curl -Ls "$url" -o "$archive"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -qO "$archive" "$url"
-  else
-    echo "[ERROR] curl or wget is required to bootstrap micromamba automatically." >&2
-    exit 1
-  fi
-  tar -xjf "$archive" -C "$tmp_dir" bin/micromamba
-  echo "$tmp_dir/bin/micromamba"
-}
-
-SOLVER_BIN=""
-if [[ -z "${CONDA_SOLVER:-}" ]]; then
-  if [[ -x "./micromamba" ]]; then
-    SOLVER_BIN=$(realpath ./micromamba)
-  elif [[ -x "${SCRIPT_DIR}/micromamba" ]]; then
-    SOLVER_BIN=$(realpath "${SCRIPT_DIR}/micromamba")
-  fi
-fi
-if [[ -n "${CONDA_SOLVER:-}" ]]; then
-  SOLVER_BIN=$CONDA_SOLVER
-elif [[ -n "$SOLVER_BIN" ]]; then
-  :
-elif command -v micromamba >/dev/null 2>&1; then
-  SOLVER_BIN=$(command -v micromamba)
-elif [[ "$UNAME" == "Linux" ]]; then
-  SOLVER_BIN=$(bootstrap_micromamba)
-elif command -v mamba >/dev/null 2>&1; then
-  SOLVER_BIN=$(command -v mamba)
-elif command -v conda >/dev/null 2>&1; then
-  SOLVER_BIN=$(command -v conda)
 else
-  echo "[ERROR] Unable to locate a conda-compatible solver. Install conda, mamba, or micromamba." >&2
-  exit 1
-fi
-
-if [[ -z "$SOLVER_BIN" ]]; then
-  echo "[ERROR] Failed to resolve solver binary." >&2
-  exit 1
-fi
-
-if [[ ! -x "$SOLVER_BIN" ]]; then
-  if command -v "$SOLVER_BIN" >/dev/null 2>&1; then
-    SOLVER_BIN=$(command -v "$SOLVER_BIN")
+  if command -v conda >/dev/null 2>&1; then
+    SOLVER_BIN=$(command -v conda)
   else
-    echo "[ERROR] Unable to execute solver '$SOLVER_BIN'." >&2
+    echo "[ERROR] Unable to locate 'conda'. Please install Anaconda or Miniconda and ensure 'conda' is on your PATH." >&2
     exit 1
   fi
 fi
 
 SOLVER_NAME=$(basename "$SOLVER_BIN")
 
-if [[ "$SOLVER_NAME" == "micromamba" ]]; then
-  export MAMBA_ROOT_PREFIX="${MAMBA_ROOT_PREFIX:-$HOME/.micromamba}"
+if [[ "$SOLVER_NAME" != "conda" ]]; then
+  echo "[ERROR] Only the 'conda' solver is supported by this script. Detected solver: '$SOLVER_NAME'." >&2
+  echo "        Set CONDA_SOLVER to the path of the 'conda' executable if needed." >&2
+  exit 1
 fi
 
 if ! "$SOLVER_BIN" env list >/dev/null 2>&1; then
-  echo "[ERROR] Solver '$SOLVER_NAME' does not support 'env list'. Ensure you are using a conda-compatible solver." >&2
+  echo "[ERROR] Solver '$SOLVER_NAME' does not support 'env list'. Ensure you are using a valid conda installation." >&2
   exit 1
 fi
 
@@ -131,11 +85,7 @@ else
   "$SOLVER_BIN" run -n "$ENV_NAME" python -m pip install -e .
 fi
 
-if [[ "$SOLVER_NAME" == "micromamba" ]]; then
-  ACTIVATE_HINT="micromamba activate ${ENV_NAME}"
-else
-  ACTIVATE_HINT="conda activate ${ENV_NAME}"
-fi
+ACTIVATE_HINT="conda activate ${ENV_NAME}"
 
 cat <<EOM
 


### PR DESCRIPTION
## Summary
- simplify solver detection in create_conda_env.sh to rely solely on the conda executable
- remove all micromamba and mamba bootstrap logic and update activation guidance

## Testing
- not run (script-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cbeb5afd5c83269ea5b0079b413fcc