### PR TITLE
Improve model download performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ python scripts/download_qwen_models.py \
   --model Qwen/Qwen2.5-Coder-32B-Instruct
 ```
 
+For the fastest results, increase `--max-workers` to saturate your bandwidth and
+ensure the optional [`hf_transfer`](https://github.com/huggingface/hf-transfer)
+package is installed. The script will enable the accelerated transfer backend
+automatically when available, or you can force it on with `--hf-transfer`.
+
 Ensure you have already authenticated with Hugging Face (`huggingface-cli
 login`) before running the script.
 


### PR DESCRIPTION
## Summary
- add CLI options to configure concurrent workers and leverage the hf_transfer backend
- automatically enable hf_transfer when installed and resume partial downloads
- document the faster download options in the README

## Testing
- pytest *(fails: scripts/create_conda_env.sh rejects fake solver shipped in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cc12333b688326a65334bef044594a