### PR TITLE
Handle legacy DistributedContext import

### DIFF
--- a/scripts/generate_voice_dataset.py
+++ b/scripts/generate_voice_dataset.py
@@ -11,7 +11,13 @@ except ImportError:  # pragma: no cover
     dist = None  # type: ignore
 
 from text2ui.config import VoiceGenerationConfig, load_voice_config
-from text2ui.voice_pipeline import DistributedContext, run_voice_pipeline
+try:
+    from text2ui.voice_pipeline import DistributedContext, run_voice_pipeline
+except ImportError:  # pragma: no cover - compatibility with older exports
+    from text2ui.voice_pipeline import (  # type: ignore
+        DisctributedContext as DistributedContext,
+        run_voice_pipeline,
+    )
 
 
 def _resolve_cli_path(path: Path) -> Path:


### PR DESCRIPTION
## Summary
- add a compatibility import in `generate_voice_dataset.py` to fall back to the legacy `DisctributedContext` symbol when available

## Testing
- python -m compileall scripts/generate_voice_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68cc7b14ea0c8326aac8f2d6eaf4df04