### PR TITLE
Handle missing DistributedContext import in voice dataset script

### DIFF
--- a/scripts/generate_voice_dataset.py
+++ b/scripts/generate_voice_dataset.py
@@ -1,5 +1,6 @@
 ﻿import argparse
 import os
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -11,7 +12,17 @@ except ImportError:  # pragma: no cover
     dist = None  # type: ignore
 
 from text2ui.config import VoiceGenerationConfig, load_voice_config
-from text2ui.voice_pipeline import DistributedContext, run_voice_pipeline
+
+try:
+    from text2ui.voice_pipeline import DistributedContext, run_voice_pipeline
+except ImportError:  # pragma: no cover - fallback for older installations
+    from text2ui.voice_pipeline import run_voice_pipeline
+
+    @dataclass
+    class DistributedContext:
+        rank: int
+        world_size: int
+        local_rank: int
 
 
 def _resolve_cli_path(path: Path) -> Path:


### PR DESCRIPTION
## Summary
- add a dataclass import and fallback DistributedContext definition
- handle ImportError when importing DistributedContext while continuing to use run_voice_pipeline

## Testing
- pytest *(fails: create_conda_env.sh only supports the real conda solver when fake solver is injected during test)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7bbff5d48326a5813a58434b8ca3