### PR TITLE
Handle legacy batch size arg and relax solver check

### DIFF
--- a/scripts/create_conda_env.sh
+++ b/scripts/create_conda_env.sh
@@ -31,11 +31,8 @@ else
 fi
 
 SOLVER_NAME=$(basename "$SOLVER_BIN")
-
 if [[ "$SOLVER_NAME" != "conda" ]]; then
-  echo "[ERROR] Only the 'conda' solver is supported by this script. Detected solver: '$SOLVER_NAME'." >&2
-  echo "        Set CONDA_SOLVER to the path of the 'conda' executable if needed." >&2
-  exit 1
+  echo "[INFO] Using non-standard solver '$SOLVER_NAME' as provided via CONDA_SOLVER." >&2
 fi
 
 if ! "$SOLVER_BIN" env list >/dev/null 2>&1; then

--- a/src/text2ui/ui_pipeline.py
+++ b/src/text2ui/ui_pipeline.py
@@ -35,7 +35,21 @@ def run_ui_pipeline(
     *,
     batch_size: int | None = None,
     max_samples: int | None = None,
+    **legacy_kwargs: object,
 ) -> List[Dict[str, object]]:
+    if "batch size" in legacy_kwargs:
+        if batch_size is not None:
+            raise TypeError(
+                "run_ui_pipeline() received both 'batch_size' and legacy 'batch size' arguments"
+            )
+        try:
+            batch_size_value = int(legacy_kwargs.pop("batch size"))
+        except (TypeError, ValueError) as exc:
+            raise TypeError("'batch size' must be convertible to an integer") from exc
+        batch_size = batch_size_value
+    if legacy_kwargs:
+        unexpected = ", ".join(sorted(legacy_kwargs))
+        raise TypeError(f"run_ui_pipeline() got unexpected keyword arguments: {unexpected}")
     voice_samples = list(read_jsonl(config.input_file))
     if max_samples is not None:
         voice_samples = voice_samples[: max(0, max_samples)]


### PR DESCRIPTION
## Summary
- accept legacy `batch size` keyword arguments when invoking the UI pipeline while still validating other unexpected kwargs
- allow the conda environment helper to work with alternative solver binaries supplied via `CONDA_SOLVER`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce5ba145748326950a1ac782db38d1