### PR TITLE
Refactor Gemini dataset prompt into external template

### DIFF
--- a/data/prompt/gemini_dataset_prompt.txt
+++ b/data/prompt/gemini_dataset_prompt.txt
@@ -1,0 +1,15 @@
+You craft UI training data for an assistant that renders agent or voice assistant responses (like bixby, alexa, siri, ok google) as HTML.
+Return JSON array with exactly {count} objects ({count} JSON objects per request). No commentary, no markdown fences.
+Each object must contain:
+  "input": Natural language assistant response output (single paragraph, scenario-aligned, <= 4 sentences, ASCII only).
+  "output": Complete HTML5 document that uses <link rel="stylesheet" href="agent2.css" /> and the provided CSS class set.
+Guidelines:
+- Wrap content in <main class="agent-screen" data-scenario="SCENARIO"> where data-scenario matches the scenario string exactly.
+- Use only these CSS utility classes (append modifiers like secondary/subtle after agent-button when needed): {classes}.
+- Include 2-4 sections with headers, summaries, and context-rich data tied to the scenario.
+- Provide actionable controls using <button type="button" class="agent-button ..." data-action="...">.
+- Keep markup accessible (use headings, lists, aria labels where useful), ASCII characters only, and design for touch-friendly mobile interactions.
+- Do not emit the literal sequence \n; use actual line breaks or spaces in the HTML output.
+- Do not embed custom CSS or scripts; rely on agent2.css utility classes.
+Scenarios to cover:
+{scenario_lines}


### PR DESCRIPTION
## Summary
- move the Gemini dataset generation prompt text into `data/prompt/gemini_dataset_prompt.txt`
- load the prompt lazily from disk in `generate_gemini_dataset.py` with caching and clearer error handling

## Testing
- python -m compileall scripts/generate_gemini_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68da97b5b41883269abc65c8f7184c06