### PR TITLE
Remove outdated comment from dataset generator

### DIFF
--- a/scripts/generate_gemini_dataset.py
+++ b/scripts/generate_gemini_dataset.py
@@ -1,10 +1,4 @@
 #!/usr/bin/env python3
-"""Generate assistant to HTML training samples with Gemini Pro or ChatGPT.
-
-This script batches scenario prompts, asks either Gemini or ChatGPT for HTML UIs that
-leverage `agent2.css` (backward compatible with agent.css), and writes the aggregated dataset to JSON.
-"""
-
 from __future__ import annotations
 
 import argparse


### PR DESCRIPTION
## Summary
- remove the obsolete module comment from `scripts/generate_gemini_dataset.py`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbbb8dc6b88326b53619dbbb1c261d