### PR TITLE
Fix font readiness waiting in dataset visualizer

### DIFF
--- a/scripts/visualize_dataset.py
+++ b/scripts/visualize_dataset.py
@@ -183,7 +183,7 @@ async def render_html_to_jpeg(
     # stabilize.  Older browsers may not expose ``document.fonts``, so we fall
     # back to a short delay in that case.
     try:
-        await page.evaluate("document.fonts.ready")
+        await page.evaluate("async () => { await document.fonts.ready; }")
     except Exception:
         await page.wait_for_timeout(200)
     else:


### PR DESCRIPTION
## Summary
- ensure the dataset visualization script waits for `document.fonts.ready` to resolve before capturing screenshots

## Testing
- not run (Playwright not installed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e53e2bae44832696211ea98b0a245e